### PR TITLE
ftol for mincresample using input volume step sizes

### DIFF
--- a/progs/mincresample/mincresample.c
+++ b/progs/mincresample/mincresample.c
@@ -1142,8 +1142,8 @@ static void transform_volume_def(Transform_Info *transform_info,
                input_volume_def->dircos[jdim][idim];
 
       /* VIO_Transform origin vector */
-      DO_INVERSE_TRANSFORM(transformed_origin, 
-                           transform_info->transformation, origin);
+      DO_INVERSE_TRANSFORM_WITH_INPUT_STEPS(transformed_origin,
+                           transform_info->transformation, origin, input_volume_def->step);
 
       /* Loop over dimensions */
       for (idim=0; idim < WORLD_NDIMS; idim++) {
@@ -1156,7 +1156,7 @@ static void transform_volume_def(Transform_Info *transform_info,
          VECTOR_SCALAR_MULT(vector, input_volume_def->dircos[idim],
                             nelements * input_volume_def->step[idim]);
          VECTOR_ADD(vector, vector, origin);
-         DO_INVERSE_TRANSFORM(vector, transform_info->transformation, vector);
+         DO_INVERSE_TRANSFORM_WITH_INPUT_STEPS(vector, transform_info->transformation, vector, input_volume_def->step);
          VECTOR_DIFF(vector, vector, transformed_origin);
 
          /* Calculate length of transformed axis - new step value */

--- a/progs/mincresample/mincresample.h
+++ b/progs/mincresample/mincresample.h
@@ -272,9 +272,19 @@ typedef struct {
       coord[XCOORD], coord[YCOORD], coord[ZCOORD], \
       &result[XCOORD], &result[YCOORD], &result[ZCOORD])
 
+#define DO_TRANSFORM_WITH_INPUT_STEPS(result, transformation, coord, input_volume_steps) \
+   general_transform_point_with_input_steps(transformation, \
+      coord[XCOORD], coord[YCOORD], coord[ZCOORD], input_volume_steps, \
+      &result[XCOORD], &result[YCOORD], &result[ZCOORD])
+
 #define DO_INVERSE_TRANSFORM(result, transformation, coord) \
    general_inverse_transform_point(transformation, \
       coord[XCOORD], coord[YCOORD], coord[ZCOORD], \
+      &result[XCOORD], &result[YCOORD], &result[ZCOORD])
+
+#define DO_INVERSE_TRANSFORM_WITH_INPUT_STEPS(result, transformation, coord, input_volume_steps) \
+   general_inverse_transform_point_with_input_steps(transformation, \
+      coord[XCOORD], coord[YCOORD], coord[ZCOORD], input_volume_steps, \
       &result[XCOORD], &result[YCOORD], &result[ZCOORD])
 
 #define IS_LINEAR(transformation) \


### PR DESCRIPTION
When using mincresample, the tolerance/precision (ftol) for calculating the position of resampled voxels is based on the step sizes of the deformation grid. These step sizes can differ from the input volume being resampled. This commit (together with a commit in the libminc repository) base the ftol variable on the step sizes of the input volume rather than the deformation grid.
