### PR TITLE
Fix crash in mincconcat when header cannot be expanded

### DIFF
--- a/progs/mincconcat/mincconcat.c
+++ b/progs/mincconcat/mincconcat.c
@@ -700,6 +700,10 @@ static void get_concat_dim_name(Concat_Info *concat_info,
 
    /* Expand the file header and open the file */
    filename = miexpand_file(first_filename, NULL, TRUE, &created_tempfile);
+   if (!filename) {
+      fprintf(stderr, "Could not expand file \"%s\"!\n", first_filename);
+      exit(EXIT_FAILURE);
+   }
    input_mincid = miopen(filename, NC_NOWRITE);
    if (created_tempfile) {
       (void) remove(filename);


### PR DESCRIPTION
This fixes a segmentation fault that occurs when an input file indicates compression (e.g. by having an extension ".bz2", ".gz", etc.), but doesn't really contain data in the corresponding compression format. In this case, exit with an error message instead of just crashing.

The issue was originally discovered by the Mayhem program analysis software in a systematic check of the whole Debian repository. The circumstances of the crash have been reported to the Debian bug tracking system as bug 716616: http://bugs.debian.org/716616
