### PR TITLE
Convert to octave-based MAT reader

### DIFF
--- a/conversion/ana2mnc/ana2mnc
+++ b/conversion/ana2mnc/ana2mnc
@@ -223,7 +223,7 @@ elsif($me eq "spm2xfm"){
       }
       
    # read in .mat file, convert to sensical format, remove first and last line
-   @dump = `mat1dump $matfile`;
+   @dump = `octave -q --eval "arg_list = argv (); filename = arg_list{4}; load(filename); disp(M)" $matfile`;
    for($c=1; $c<4; $c++){
       $dump[$c] =~ s/\t/\ /g;
       if($c == 3){ 
@@ -255,7 +255,7 @@ elsif($me eq "spm_show"){
    if(!-e $matfile){ 
       die "$me: Couldn't find $matfile\n\n"; 
       }
-   print STDOUT `mat1dump $matfile`;
+   print STDOUT `octave -q --eval "arg_list = argv (); filename = arg_list{4}; load(filename); disp(M)" $matfile`;
    }
 
 


### PR DESCRIPTION
mat1dump (which ana2mnc uses to read mat files) is limited to old versions of the mat format.

Octave can read newer versions.

@andrewjanke I can't check if octave prints the matrix the same way it was stored internally, this is the way octave prints the .mat matrix.

```
$ spm_show 1001794_wba_001.mat
    -0.46875     0.00000     0.00000   120.46875
     0.00000    -0.46875     0.00000   136.83240
     0.00000     0.00000     1.50000   -66.20751
     0.00000     0.00000     0.00000     1.00000
```
