### PR TITLE
sepearated the "mincextract ... | convert ..." command into 2 seperate &do_cmd to avoid piping errors

### DIFF
--- a/progs/mincpik/mincpik.in
+++ b/progs/mincpik/mincpik.in
@@ -14,8 +14,7 @@
 
 use strict;
 use warnings "all";
-use Getopt::Long;
-use Pod::Usage;
+use Getopt::Tabular;
 use File::Basename;
 use File::Temp qw/ tempdir /;
 
@@ -31,12 +30,11 @@ my(@args, $args, $infile, $outfile, %ordering, $CODE);
 
 $me = &basename($0);
 %opt = (
-   'help' => 0,
-   'man' => 0,
    'verbose' => 0,
    'clobber' => 0,
    'fake' => 0,
    
+   'slice' => undef,
    'scale' => 2,
    'width' => undef,
    'bitdepth' => 8,
@@ -44,8 +42,6 @@ $me = &basename($0);
    'image_range' => undef,
    'auto_range' => 0,
    'lookup' => undef,
-   
-   'slice' => undef,
    'dirs' => ['zspace'],
    
    'triplanar' => 0,
@@ -59,54 +55,113 @@ $me = &basename($0);
    'anot_bar' => undef,
    );
 
-# Check arguments
-&GetOptions(
-   'help|?' => \$opt{'help'},
-   'man' => \$opt{'man'},
-   'version' => sub { &print_version_info },
-   'v|verbose' => \$opt{'verbose'},
-   'c|clobber' => \$opt{'clobber'},
-   'f|fake' => \$opt{'fake'},
-   
-   'scale=i' => \$opt{'scale'},
-   'width=i' => \$opt{'width'},
-   'depth=i' => \$opt{'bitdepth'},
-   
-   'title' => \$opt{'title'},
-   'title_text=s' => \$opt{'title_text'},
-   'title_size=i' => \$opt{'title_size'},
-   'anot_bar=s' => \$opt{'anot_bar'},
-   
-   # Image range and lookup table options
-   'range=f{2}' => \@{$opt{'range'}},
-   'image_range=f{2}' => \@{$opt{'image_range'}},
-   'auto_range' => \$opt{'auto_range'},
-   'lookup=s' => \$opt{'lookup'},
-   
-   # Slicing options
-   's|slice=i' => \$opt{'slice'},
-   'z|axial|transverse' => sub { $opt{'dirs'} = ['zspace']; },
-   'y|coronal' => sub { $opt{'dirs'} = ['yspace']; },
-   'x|sagittal' => sub { $opt{'dirs'} = ['xspace']; },
-   
-   # triplanar options
-   't|triplanar' => \$opt{'triplanar'},
-   'tilesize=i' => \$opt{'tilesize'},
-   'sagittal_offset=i' => \$opt{'sagittal_offset'},
-   'sagittal_offset_perc=i' => \$opt{'sagittal_offset_perc'},
-   'vertical' => \$opt{'orientation'},
-   'horizontal' => \$opt{'orientation'},
-   ) or pod2usage(-verbose => 1) && exit;
+$Help = <<HELP;
+| $me generates image files from MINC volumes using the Imagemagick
+|    convert utility. For a complete list of output file types see the
+|    convert man pages. (man convert) The resulting image is piped to
+|    STDOUT
+|
+| EXAMPLES:
+| To display a default view, transverse slicing, middle slice
+| using display. (display is part of the Imagemagick package)
+|
+|    \$ mincpik infile.mnc PNG:- | display -
+|
+| To generate a PNG file of the 15th coronal slice
+|
+|    \$ mincpik -slice 15 -coronal infile.mnc outfile.png
+|
+| To generate a JPG file using the hotmetal lookup table
+|    with the image range 0 to 100
+|
+|    \$ mincpik -lookup '-hotmetal' -image_range 0 100 infile.mnc outfile.jpg
+|
+| ImageMagick:  http://www.wizards.dupont.com/cristy/ImageMagick.html
+|    NB: ImageMagick should be compiled without 16-bit quanta.
+|
+| Problems or comments should be sent to: a.janke\@gmail.com
+HELP
 
-# handle -man, -help or missing args
-pod2usage(-verbose => 1) if $opt{'help'};
-pod2usage(-exitstatus => 0, -verbose => 2) if $opt{'man'};
-pod2usage(-verbose => 0) && exit if ($#ARGV != 1);
+$Usage = "Usage: $me [options] <infile.mnc> [<image.type>]\n".
+         "       $me -help to list options\n\n";
+
+@opt_table = (
+   ['-verbose', 'boolean', 0, \$opt{'verbose'},
+      'be verbose'],
+   ['-clobber', 'boolean', 0, \$opt{'clobber'},
+      'overwrite existing files'],
+   ['-fake', 'boolean', 0, \$opt{'fake'},
+      'do a dry run, (echo cmds only)' ],
+   ['-slice', 'integer', 1, \$opt{'slice'},
+      'slice number to get',
+      '<int>'],
+   ['-scale', 'integer', 1, \$opt{'scale'},
+      'scaling factor for resulting image',
+      '<int>'],
+   ['-width', 'integer', 1, \$opt{'width'},
+      'autoscale the image to have a fixed image width (in pixels)',
+      '<int>'],
+   ['-depth', 'integer', 1, \$opt{'bitdepth'},
+      'bitdepth for resulting image 8 or 16 (MSB machines only!)',
+      '<int>'],
+   ['-title', "boolean", 0, \$opt{'title'},
+      "add a title to the resulting image"],
+   ['-title_text', "string", 1, \$opt{'title_text'},
+      "use <string> for the title [default: input-filename]",
+      "<string>"],
+   ['-title_size', "integer", 1, \$opt{'title_size'},
+      "font point size for the title",
+      "<int>"],
+   ['-anot_bar', "string", 1, \$opt{'anot_bar'},
+      "create an annotated bar to match the image (use height of the output image)",
+      "<fname.png>"],
+   
+   ['Image range and lookup table options', 'section' ],
+   ['-range', 'float',   2, \@{$opt{'range'}},
+      'valid range of values for MINC file',
+      '<real> <real>'],
+   ['-image_range', 'float', 2, \@{$opt{'image_range'}},
+      'range of image values to use for pixel intensity',
+      '<real> <real>'],
+   ['-auto_range', 'boolean', 0, \$opt{'auto_range'},
+      'automatically determine image range'],
+   ['-lookup', 'string', 1, \$opt{'lookup'},
+      'arguments to pass to minclookup',
+      '<\'argument list\'>'],
+   
+   ['Slicing options', 'section' ],
+   ['-transverse', 'arrayconst', ['zspace'], \@{$opt{'dirs'}},
+      'get a transverse slice'],
+   ['-axial', 'arrayconst', ['zspace'], \@{$opt{'dirs'}},
+      'synonym for transverse'],
+   ['-coronal', 'arrayconst', ['yspace'], \@{$opt{'dirs'}},
+      'get a coronal slice'],
+   ['-sagittal', 'arrayconst', ['xspace'], \@{$opt{'dirs'}},
+      'get a sagital slice'],
+   ['-allthree', 'arrayconst', ['zspace', 'xspace', 'yspace'], \@{$opt{'dirs'}},
+      'you probably dont want this, it is somewhat broken, use -triplanar instead'],
+   
+   ['triplanar options', 'section' ],
+   ['-triplanar', 'boolean', 0, \$opt{'triplanar'},
+      'create a triplanar view of the input MINC file'],
+   ['-tilesize', "integer", 1, \$opt{'tilesize'},
+      "pixel size for each image in a triplanar"],
+   ['-sagittal_offset', "integer", 1, \$opt{'sagittal_offset'},
+      "offset the sagittal slice from the centre",
+      "<# slices>"],
+   ['-sagittal_offset_perc', "integer", 1, \$opt{'sagittal_offset_perc'},
+      "offset the sagittal slice by a percentage from the centre",
+      "<% offset>"],
+   ['-vertical', 'const', 'vertical', \$opt{'orientation'},
+     'create a vertical triplanar view (Default)'],
+   ['-horizontal', 'const', 'horizontal', \$opt{'orientation'},
+     'create a horizontal triplanar view'],
+   );
 
 # Check arguments
-#&Getopt::Tabular::SetHelp ($Help, $Usage);
-#&GetOptions (\@opt_table, \@ARGV) || exit 1;
-#die $Usage if ($#ARGV < 0);
+&Getopt::Tabular::SetHelp ($Help, $Usage);
+&GetOptions (\@opt_table, \@ARGV) || exit 1;
+die $Usage if ($#ARGV < 0);
 
 # create temporary directory
 $tmpdir = &tempdir( "$me-XXXXXXXX", TMPDIR => 1, CLEANUP => 1 );
@@ -145,7 +200,7 @@ if($opt{'triplanar'}){
    }
 
 my ($space, $n_slices, $convert_infile, $imgfile,
-    @extract_args, @convert_args,
+    @extract_args, @convert_args, $extract_output,
     $img_x, $img_y,
     $img_step_x, $img_step_y, 
     $img_length_x, $img_length_y,
@@ -286,25 +341,27 @@ foreach $space (@{$opt{'dirs'}}){
                     '-normalize',
                     ($opt{'bitdepth'} == 16) ? ('-short', '-unsigned') : '-byte');
    
+   #set the path for the mincextract output
+   $extract_output = "$tmpdir/extracted.raw";
+
    # set up convert arguments
    # a flip is 'normal' due to the difference between mnc and most image co-ordinates
    @convert_args = ('convert',
                     '-depth', $opt{'bitdepth'},
-                    '-flip', 
+                    '-flip',
                     '-size', $img_y . 'x' . $img_x,
                     '-geometry', $img_length_y . 'x' . $img_length_x . '!',
-                    "$CODE:-", $imgfile);
+                    "$CODE:$extract_output", $imgfile);
    
-   # check if we are big or little endian for convert's MSB wierdity
-   $pipe_args = '|';
-   if($opt{'bitdepth'} == 16){
-      if(unpack("c",substr(pack("s",1),0,1))){
-         warn "$me: LSB machine, swapping bytes with dd and crossing fingers\n";
-         $pipe_args .= ' dd conv=swab | ';
-         }
-      }
+   $pipe_args = '>';
    
-   &do_cmd(join(' ', @extract_args, $pipe_args, @convert_args));
+   #preform the mincextract
+   &do_cmd(join(' ', @extract_args, $pipe_args, $extract_output));
+   
+   #preform the convert 
+   &do_cmd(@convert_args);
+
+
    }
 
 # do the triplanar if requested
@@ -377,7 +434,7 @@ if(defined($opt{'anot_bar'})){
    $bw = int($bh/10);
    
    # get range if not defined
-   if(!defined($opt{'image_range'}[0])){
+   if(!(@{$opt{'image_range'}[0]})){
       print STDERR "Getting image range\n" if $opt{'verbose'};
       
       @buf = split(/\n/, `mincstats -min -max -quiet $infile`);
@@ -465,207 +522,3 @@ sub do_cmd {
       system(@_) == 0 or die "\n$me: Failed executing @_\n\n";
       }
    }
-
-# print version information
-sub print_version_info {
-   my $PACKAGE = '@PACKAGE_NAME@';
-   my $VERSION = '@PACKAGE_VERSION@';
-   my $PACKAGE_BUGREPORT = '@PACKAGE_BUGREPORT@';
-   
-   print STDOUT "\n$PACKAGE version $VERSION\n".
-                "Comments to $PACKAGE_BUGREPORT\n\n";
-   exit 0;
-   }
-
-__END__
-
-=head1 NAME
-
-B<mincpik> - generate images from minc files
-
-=head1 SYNOPSIS
-
-B<mincpik> [options] <infile>.mnc [<image.type>]
-
-mincpik generates image files from MINC volumes using the Imagemagick
-convert utility. Use -help or -man for more information and examples
-
-=head1 DESCRIPTION
-
-B<mincpik> generates image files from MINC volumes using the Imagemagick
-B<convert> utility. For a complete list of output file types see the
-B<convert> man pages.
-
-EXAMPLES:
-To display a default view, axial (z) slicing, middle slice
-using display. (display is part of the Imagemagick package)
-
-   mincpik infile.mnc PNG:- | display -
-
-To generate a PNG file of the 15th coronal slice
-
-   mincpik -slice 15 -coronal infile.mnc outfile.png
-
-To generate a JPG file using the hotmetal lookup table 
-with the image range 0 to 100
-
-   mincpik -lookup '-hotmetal' -image_range 0 100 infile.mnc outfile.jpg
-
-ImageMagick:  http://www.wizards.dupont.com/cristy/ImageMagick.html
-   NB: ImageMagick should be compiled without 16-bit quanta.
-
-Currently if there is a time dimension in the file the image will
-only produced from the first time point
-
-Problems or comments should be sent to: a.janke\@gmail.com
-
-=head1 OPTIONS
-
-=over 4
-
-=item B<-v>, B<--verbose>
-
-Be noisy when doing things
-
-=item B<--version>
-
-Print version number and exit
-
-=item B<-?>, B<--help>
-
-Dump some quick help output
-
-=item B<--man>
-
-Dump a man page
-
-=item B<-c> B<--clobber>
-
-overwrite the output file if it exists already
-
-=item B<-f> B<--fake>
-
-do a dry run, (echo cmds only). This is usually used in combination with -verbose to echo commands only
-
-=item B<--scale>
-
-scaling factor for resulting image, by default images are output 
-at twice their original resolution
-
-=item B<--width>
-
-autoscale the resulting image to have a fixed image width (in pixels)
-
-=item B<--depth>
-
-bitdepth for resulting image 8 or 16 (MSB machines only!)
-
-=item B<--title>
-
-add a title to the resulting image, if just this option is specified the text used for the title is the name of the input image file.
-
-=item B<--title_text>
-
-use the input string for the title [default: input-filename]. This option must be used in conjunction with -title
-
-=item B<--title_size>
-
-font point size for the title
-
-=item B<--anot_bar>
-
-create an annotated bar to match the image (use height of the output image)
-
-=back
-
-
-=head2 Image range and lookup table options
-
-=over 4
-
-=item B<--range>
-
-valid range of values for MINC file
-
-=item B<--image_range>
-
-range of image values to use for pixel intensity
-
-=item B<--auto_range>
-
-automatically determine image range using a 5 and 95% PcT. (histogram)
-
-=item B<--lookup>
-
-arguments to pass to minclookup
-
-=back
-
-
-=head2 Slicing options
-
-=over 4
-
-=item B<-s> B<--slice>
-
-slice number to get. (note this is in voxel co-ordinates)
-
-=item B<-z> B<--axial> B<--transverse>
-
-get an axial/transverse (z) slice
-
-=item B<-y> B<--coronal>
-
-get a coronal (y) slice
-
-=item B<-x> B<--sagittal>
-
-get a sagital (x) slice
-
-=back
-
-
-=head2 Triplanar options
-
-=over 4
-
-=item B<-t> B<--triplanar>
-
-create a triplanar view of the input file
-
-=item B<--tilesize>
-
-pixel size for each image in a triplanar
-
-=item B<--sagittal_offset>
-
-offset the sagittal slice from the centre
-
-=item B<--sagittal_offset_perc>
-
-offset the sagittal slice by a percentage from the centre
-
-=item B<--vertical>
-
-create a vertical triplanar view (Default)
-
-=item B<--horizontal>
-
-create a horizontal triplanar view
-
-=back
-
-
-=head1 SEE ALSO
-
-convert(1) mincextract(1) display(1)
-
-=head1 AUTHOR
-
-Andrew Janke - a.janke@gmail.com
-
-=head1 COPYRIGHTS
-
-Copyright 2012 by Andrew L Janke
-
-=cut


### PR DESCRIPTION
sepearated the "mincextract ... | convert ..." command into 2 seperate &do_cmd to avoid piping errors