### PR TITLE
Changed mincmorph to be more permissive with dimension order

### DIFF
--- a/progs/mincmorph/mincmorph.c
+++ b/progs/mincmorph/mincmorph.c
@@ -202,7 +202,7 @@ int main(int argc, char *argv[])
    double   min, max;
    char    *ptr;
 
-   char    *axis_order[VIO_MAX_DIMENSIONS] = { MIzspace, MIyspace, MIxspace, MItime, MIvector_dimension };
+   char    *axis_order[VIO_MAX_DIMENSIONS] = { MIzspace, MIyspace, MIxspace, "", "" };
 
    /* Save time stamp and args */
    arg_string = time_stamp(argc, argv);


### PR DESCRIPTION
Small fix for the issue discussed with @andrewjanke.
That way mincmorph will only require that the spatial dimensions are first while allowing vector_dimension and time to be in any order if they are present. 