### PR TITLE
add fclose to mincextract

### DIFF
--- a/progs/mincextract/mincextract.c
+++ b/progs/mincextract/mincextract.c
@@ -490,6 +490,13 @@ int main(int argc, char *argv[])
    }       /* End loop over slices */
 
    /* Clean up */
+   if (fclose(stdout) == EOF){
+       fprintf(stderr, "Error closing stdout.\n");
+       exit(EXIT_FAILURE);
+   }
+   if (fclose(stderr) == EOF){
+       exit(EXIT_FAILURE);
+   }
    (void) miclose(mincid);
    (void) miicv_free(icvid);
    free(data);


### PR DESCRIPTION
This fixes a bug I was experience with `mincpik`. Specifically, `mincpik` would often fail when piping `mincextract` into `convert`. This seems to be caused by `mincextract` exiting before all the image data is written to stdout. I believe this PR fixes this.