### PR TITLE
skip image if marked as invalid

### DIFF
--- a/conversion/dcm2mnc/dicom_to_minc.c
+++ b/conversion/dcm2mnc/dicom_to_minc.c
@@ -555,6 +555,7 @@ dicom_to_minc(int num_files,
         if (!fi_ptr[ifile].valid) {
             printf("WARNING: file %s was marked invalid\n", 
                    file_list[ifile]);
+            iimage++;
             continue;
         }
      
@@ -577,6 +578,7 @@ dicom_to_minc(int num_files,
                 fprintf(stderr, "WARNING: parsing file '%s' during 2nd pass.\n",
                         file_list[ifile]);
                 fi_ptr[ifile].valid = FALSE;
+                iimage++;
                 continue;
             }
         }


### PR DESCRIPTION
Hi,

I have encountered a data-set that has an non-image DICOM (missing pixel data) and it affects the overall result of the converted volume. Here is a proposed solution that fixes the issue by skipping the invalid file.