### PR TITLE
Uniformize tmpdir handling in shell scripts

### DIFF
--- a/progs/mincdiff/mincdiff
+++ b/progs/mincdiff/mincdiff
@@ -65,24 +65,16 @@ while test $# -gt 2; do
 done
 test $# -eq 2 || die "Usage: $0 [-header|-body] [-l] [diff options] <file1.mnc> <file2.mnc>"
 
-if test x$TMPDIR = x; then
-    for TMPDIR in /usr/tmp /var/tmp /tmp; do
-	test -d $TMPDIR && break;
-    done
-fi
-test -d $TMPDIR || die "TMPDIR $TMPDIR does not exist."
-
+tmpdir=`mktemp -d`
+trap "rm -rf $tmpdir" EXIT QUIT HUP INT TERM
 
 # Files created
-tmp1="$TMPDIR/mincdiff-$$-tmp1"
-tmp2="$TMPDIR/mincdiff-$$-tmp2"
-header1="$TMPDIR/mincdiff-$$-header1"
-header2="$TMPDIR/mincdiff-$$-header2"
-body1="$TMPDIR/mincdiff-$$-body1"
-body2="$TMPDIR/mincdiff-$$-body2"
-
-# Clean up upon exit
-trap "/bin/rm -f $tmp1 $tmp2 $header1 $header2 $body1 $body2" 0 1 2 15
+tmp1="$tmpdir/mincdiff-$$-tmp1"
+tmp2="$tmpdir/mincdiff-$$-tmp2"
+header1="$tmpdir/mincdiff-$$-header1"
+header2="$tmpdir/mincdiff-$$-header2"
+body1="$tmpdir/mincdiff-$$-body1"
+body2="$tmpdir/mincdiff-$$-body2"
 
 # Expand the files
 dumpfile1=`mincexpand $1 $tmp1 -name_only`

--- a/progs/mincedit/mincedit
+++ b/progs/mincedit/mincedit
@@ -87,13 +87,9 @@ me=`basename $0`
 usage="Usage: $me <minc file> [<editor>]"
 
 # create tmpdir
-tmpdir=${TMPDIR:-/tmp}/mincedit.$$
-trap 'rm -rf "$tmpdir"' 0
-trap ' exit ' 0 1 2 3 15
-(umask 077 && mkdir $tmpdir) || {
-   echo "$me: Could not create temporary directory! Exiting." 1>&2 
-   exit 1
-   }
+tmpdir=`mktemp -d`
+trap "rm -rf $tmpdir" EXIT QUIT HUP INT TERM
+
 
 # check arguments
 case $# in

--- a/progs/mincheader/mincheader
+++ b/progs/mincheader/mincheader
@@ -65,15 +65,8 @@ die () {
     exit 1
 }
 
-# create tmpdir
-tmpdir=${TMPDIR:-/tmp}/mincedit.$$
-trap 'rm -rf "$tmpdir"' 0
-trap ' exit ' 1 2 15
-(umask 077 && mkdir $tmpdir) || {
-   echo "$0: Could not create temporary directory! Exiting." 1>&2
-   echo ""
-   exit 1
-   }
+tmpdir=`mktemp -d`
+trap "rm -rf $tmpdir" EXIT QUIT HUP INT TERM
 
 me=`basename $0`
 usage="Usage: $me [-data] <minc file>"

--- a/progs/mincview/mincview
+++ b/progs/mincview/mincview
@@ -25,13 +25,10 @@ fi
 
 infile="$1"
 
-# Create temporary directory
-tmpdir="/tmp/mincview-$$"
 
-# cleanup nicely
-trap "rm -rf $tmpdir" 0 1 2 3 13 15
+tmpdir=`mktemp -d`
+trap "rm -rf $tmpdir" EXIT QUIT HUP INT TERM
 
-mkdir -p $tmpdir
 
 # Get dimension names
 dims=( $(mincinfo -vardims image $infile ) )


### PR DESCRIPTION
@zijdenbos 

Fixes #105 

Here's a draft of fixes for the tmpdir handling, locally for me they now get created and cleaned up on exit.

A note regarding cluster integration, since we're now honouring the environment "TMPDIR" variable with mktemp, even if the job is interrupted, the TMPDIR is set by most cluster systems to be job-id linked, so when the job goes away, the cluster cleans up the directory. Nevertheless I also added an exit trap for cleanup.