### PR TITLE
Fix build error with GCC 10 due to missing …

### DIFF
--- a/conversion/minctoecat/ecat_write.c
+++ b/conversion/minctoecat/ecat_write.c
@@ -11,6 +11,8 @@
 #define ERROR   -1
 #define V7 70
 
+MatrixErrorCode matrix_errno;
+char matrix_errtxt[132];
 
 char* dstypecode[NumDataSetTypes] =
 	{ "u","s","i","a","n","pm","v8","v","p8","p","i8","S","S8","N", "FS"};

--- a/conversion/minctoecat/ecat_write.h
+++ b/conversion/minctoecat/ecat_write.h
@@ -39,9 +39,9 @@ typedef enum {
   BitData
 } MatrixDataType;
 
-MatrixErrorCode matrix_errno;
+extern MatrixErrorCode matrix_errno;
 
-char matrix_errtxt[132];
+extern char matrix_errtxt[132];
 
 typedef struct XMAIN_HEAD {
   char magic_number[14];


### PR DESCRIPTION
GCC version 10 now defaults to -fno-common; see https://gcc.gnu.org/gcc-10/porting_to.html.  The practical result of this is a compile error in minctoecat due to multiple definitions; see below.  

Fix is to add "extern" modifier to matrix_errno and matrix_errtxt declarations  in ecat_write.h; define these two in ecat_write.c.


FAILED: conversion/minctoecat 
: && /usr/bin/cc   -rdynamic conversion/CMakeFiles/minctoecat.dir/minctoecat/minctoecat.c.o conversion/CMakeFiles/minctoecat.dir/minctoecat/ecat_write.c.o conversion/CMakeFiles/minctoecat.dir/minctoecat/machine_indep.c.o  -o conversion/minctoecat  -Wl,-rpath,/usr/lib/x86_64-linux-gnu/hdf5/serial:  -lminc2  /usr/lib/x86_64-linux-gnu/hdf5/serial/libhdf5.so  -lpthread  -lsz  -lz  -ldl  -lm  -lz  -lm  -ldl  -lrt  -lnetcdf  -lminc2  -lminc2  /usr/lib/x86_64-linux-gnu/hdf5/serial/libhdf5.so  -lpthread  -lsz  -lz  -ldl  -lm  -lz  -lm  -ldl  -lrt  -lnetcdf  -lm  -lminc2  /usr/lib/x86_64-linux-gnu/hdf5/serial/libhdf5.so  -lpthread  -lsz  -lz  -ldl  -lm  -ldl  -lrt  -lnetcdf  -lminc2  /usr/lib/x86_64-linux-gnu/hdf5/serial/libhdf5.so  -lpthread  -lsz  -lz  -ldl  -lm  -lm  -ldl  -lrt  -lnetcdf && :
/usr/bin/ld: conversion/CMakeFiles/minctoecat.dir/minctoecat/ecat_write.c.o:(.bss+0x0): multiple definition of `matrix_errno'; conversion/CMakeFiles/minctoecat.dir/minctoecat/minctoecat.c.o:(.bss+0x0): first defined here
/usr/bin/ld: conversion/CMakeFiles/minctoecat.dir/minctoecat/ecat_write.c.o:(.bss+0x20): multiple definition of `matrix_errtxt'; conversion/CMakeFiles/minctoecat.dir/minctoecat/minctoecat.c.o:(.bss+0x20): first defined here
/usr/bin/ld: conversion/CMakeFiles/minctoecat.dir/minctoecat/machine_indep.c.o:(.bss+0x0): multiple definition of `matrix_errno'; conversion/CMakeFiles/minctoecat.dir/minctoecat/minctoecat.c.o:(.bss+0x0): first defined here
/usr/bin/ld: conversion/CMakeFiles/minctoecat.dir/minctoecat/machine_indep.c.o:(.bss+0x20): multiple definition of `matrix_errtxt'; conversion/CMakeFiles/minctoecat.dir/minctoecat/minctoecat.c.o:(.bss+0x20): first defined here
collect2: error: ld returned 1 exit status



