### PR TITLE
Fix bounds in index of next slice

### DIFF
--- a/progs/mincresample/resample_volumes.c
+++ b/progs/mincresample/resample_volumes.c
@@ -731,12 +731,12 @@ int trilinear_interpolant(Volume_Data *volume,
              f1r2 * v010 +
              f1f2 * v011) + volume->offset[slcind]);
    *result +=
-      f0 * (volume->scale[slcind+1] *
+      f0 * (volume->scale[slcnext] *
             (r1r2 * v100 +
              r1f2 * v101 +
              f1r2 * v110 +
-             f1f2 * v111) + volume->offset[slcind+1]);
-   
+             f1f2 * v111) + volume->offset[slcnext]);
+
    return TRUE;
 
 }


### PR DESCRIPTION
#111 

For volumes with a slice dimension of size one, the index of the
next slice will sometimes be set to 1 and exceed array bounds.
This changes the index used to the one that is correctly set to slcnext,
which is correctly set to 0.