### PR TITLE
Make major modifications to dcm2mnc towards better support of a variety of datasets

### DIFF
--- a/conversion/dcm2mnc/acr_element_defs.h
+++ b/conversion/dcm2mnc/acr_element_defs.h
@@ -165,9 +165,14 @@ GLOBAL_ELEMENT(ACR_Window_width          , 0x0028, 0x1051, DS);
 GLOBAL_ELEMENT(ACR_Rescale_intercept     , 0x0028, 0x1052, DS);
 GLOBAL_ELEMENT(ACR_Rescale_slope         , 0x0028, 0x1053, DS);
 
+GLOBAL_ELEMENT(ACR_RealWorldValueMappingSequence      , 0x0040, 0x9096, SQ);
+GLOBAL_ELEMENT(ACR_RealWorldValue_Intercept           , 0x0040, 0x9224, FD);
+GLOBAL_ELEMENT(ACR_RealWorldValue_Slope               , 0x0040, 0x9225, FD);
 GLOBAL_ELEMENT(ACR_Detector_information_seq, 0x0054, 0x0022, SQ);
 GLOBAL_ELEMENT(ACR_Number_of_slices      , 0x0054, 0x0081, US);
 GLOBAL_ELEMENT(ACR_Number_of_time_slices , 0x0054, 0x0101, US);
+GLOBAL_ELEMENT(ACR_Number_of_Mosaic_Images , 0x0019, 0x100a, US);
+GLOBAL_ELEMENT(ACR_Number_of_Echoes      , 0x0019, 0x107e, SS);
 GLOBAL_ELEMENT(ACR_Units                 , 0x0054, 0x1001, CS);
 GLOBAL_ELEMENT(ACR_Frame_reference_time  , 0x0054, 0x1300, DS);
 GLOBAL_ELEMENT(ACR_PET_Image_index       , 0x0054, 0x1330, US);

--- a/conversion/dcm2mnc/dcm2mnc.h
+++ b/conversion/dcm2mnc/dcm2mnc.h
@@ -205,10 +205,11 @@ typedef struct {
     int rec_num;
     int image_type;
     int num_echoes;
-    int echo_number;
+    double echo_number; // Use dbl in case we use the e. time as e. nmbr
     int num_dyn_scans;
     int dyn_scan_number;
     int global_image_number;
+    int pet_image_index;
     int num_slices_nominal;
     int slice_number;
     int acq_rows;
@@ -222,6 +223,7 @@ typedef struct {
     string_t protocol_name;
     string_t patient_name;
     string_t patient_id;
+    string_t image_type_string;
     double slice_location;
     int coord_found;
     double coord[WORLD_NDIMS];
@@ -256,6 +258,7 @@ struct globals {
     char * command_line;
     int opts;
     mosaic_seq_t mosaic_seq;
+    int num_partitions;
     int use_stdin;
     int use_filelist; 		/*use file with list of filenames   ilana*/
     char * filename_format;
@@ -263,6 +266,7 @@ struct globals {
     int prefer_coords;           /* In event of slice thickness conflict, 
                                     use the coordinate information rather 
                                     than the slice thickness or spacing. */
+    int ignore_empty_time;      /* Ignore empty timeframes */
     int min_acq_num;            /* Minimum acquisition number (0020,0012). */
     int max_acq_num;            /* Maximum acquisition number. */
     int min_img_num;            /* Minimum image number (0020,0013). */
@@ -274,6 +278,16 @@ struct globals {
     int ignore_leading_dot;     /* If TRUE, ignore files with leading '.' */
     int file_format;            /* Preferred MINC file format (1 or 2). */
     int n_distinct_coordinates; /* Total number of distinct coordinates. */
+    int n_slices_nominal;
+    int n_files;
+    int n_files_total;
+    int bogus_PET_index;
+    int bogus_frame_reference_time;
+    int bogus_trigger_time;
+    int bogus_temporal_id;
+    double sliceNormV1;
+    double sliceNormV2;
+    double sliceNormV3;
 };
 
 /* Values for options flags */

--- a/conversion/dcm2mnc/dicom_read.h
+++ b/conversion/dcm2mnc/dicom_read.h
@@ -11,6 +11,11 @@ extern int dicom_read_position(Acr_Group group_list, int n, double position[3]);
 extern int dicom_read_orientation(Acr_Group group_list, double orientation[6]);
 extern int dicom_read_pixel_size(Acr_Group group_list, double pixel_size[2]);
 
+extern double get_slice_separation( Acr_Group group_list);
+extern void calculate_dircos(double RowColVec[6], double dircos[VOL_NDIMS][WORLD_NDIMS], int do_coordinate_conversion);
+extern double convert_seconds_to_time(double seconds);
+extern double convert_time_to_seconds(double dicomtime);
+
 extern void convert_dicom_coordinate(double coord[]);
 extern int is_numaris3(Acr_Group group_list);
 

--- a/conversion/dcm2mnc/dicom_to_minc.h
+++ b/conversion/dcm2mnc/dicom_to_minc.h
@@ -104,6 +104,8 @@
 #define SECONDS_PER_DAY (HOURS_PER_DAY*SECONDS_PER_HOUR)
 #define MS_PER_SECOND 1000
 #define COORDINATE_EPSILON (0.005) /* bert- relaxed from 1.0e-5 */
+#define DICOM_SECONDS_PER_HOUR 10000.0
+#define DICOM_SECONDS_PER_MINUTE 100.0
 
 /* Default value for ncopts */
 #define NCOPTS_DEFAULT NC_VERBOSE
@@ -178,6 +180,9 @@ typedef struct {
     int num_slices_in_file;
     int sub_image_rows;
     int sub_image_columns;
+    int fix_multi_echo_fMRI;
+    int found_philips_MRLabels;
+    int missing_scale;
     struct {
         string_t name;
         string_t identification;
@@ -288,7 +293,9 @@ typedef struct {
    double b_matrix[B_MATRIX_COUNT]; 
    int tpos_id; /* Temporal position identifier (for GE slice order) */
    double trigger_time; /* Trigger time (for GE slice order) */
+   double RTIA_timer; /* RTIA timer (for GE slice order) */
    double slice_location; /* Slice location (for GE slice order) */
+   double rep_time; /* Repetition time (for time positions) */
 } File_Info;
 
 /* Structure for storing the actual image data */
@@ -304,7 +311,7 @@ extern int dicom_to_minc(int num_files,
                          const char *file_prefix, 
                          const char **output_file_name);
 extern Acr_Group read_std_dicom(const char *filename, int max_group);
-extern Acr_Group read_numa4_dicom(const char *filename, int max_group, int num_files);
+extern Acr_Group read_numa4_dicom(const char *filename, int max_group);
 extern int search_list(int value, const int *list_ptr, int list_length, 
                        int start_index);
 extern Acr_Group copy_spi_to_acr(Acr_Group group_list);

--- a/conversion/dcm2mnc/gems_element_defs.h
+++ b/conversion/dcm2mnc/gems_element_defs.h
@@ -45,13 +45,20 @@ GLOBAL_ELEMENT(GEMS_Fast_phases            , 0x0019, 0x10f2, SS);
 
 GLOBAL_ELEMENT(GEMS_Sers_private_creator_id, 0x0025, 0x0010, SH);
 GLOBAL_ELEMENT(GEMS_Images_in_series       , 0x0025, 0x1007, SL);
+GLOBAL_ELEMENT(GEMS_Number_of_acquisitions, 0x0025, 0x1011, SS);
 
 /* From GEHC-DICOM-Conformance_DV231_DOC1143469_Rev1.pdf */
 
 GLOBAL_ELEMENT(GEMS_Rela_private_creator_id, 0x0021, 0x0010, SH);
 GLOBAL_ELEMENT(GEMS_Locations_in_acquisition, 0x0021, 0x104f, SS);
+GLOBAL_ELEMENT(GEMS_RTIA_timer, 0x0021, 0x105e, DS);
 
-GLOBAL_ELEMENT(GEMS_Image_type, 0x0043, 0x102f, SS);
+/* From https://www3.gehealthcare.com/~/media/documents/us-global/products/interoperability/dicom/magnetic-resonance/gehc-dicom-conformance_dv231_doc1143469_rev1.pdf
+and comparing with actual data given the undefined 'User data #' fields */
+
+GLOBAL_ELEMENT(GEMS_Diffusion_direction_x, 0x0019, 0x10bb, DS);
+GLOBAL_ELEMENT(GEMS_Diffusion_direction_y, 0x0019, 0x10bc, DS);
+GLOBAL_ELEMENT(GEMS_Diffusion_direction_z, 0x0019, 0x10bd, DS);
 
 /* not yet fully defined */
 /* from http://www.gehealthcare.com/usen/interoperability/dicom/docs/5162373r1.pdf */
@@ -63,7 +70,6 @@ GLOBAL_ELEMENT(GEMS_DTI_diffusion_directions, 0x0019, 0x10e0, DS);
 GLOBAL_ELEMENT(GEMS_DTI_diffusion_directions, 0x0019, 0x10df, DS);
 GLOBAL_ELEMENT(GEMS_Concatenated_SAT, 0x0019, 0x10d9, DS);
 GLOBAL_ELEMENT(GEMS_Diffusion_direction, 0x0021, 0x105a, SL);
-
 /* this field apparently consists of 4 integers - the first gives the
  * b-value in DTI??
  */

--- a/conversion/dcm2mnc/minc_file.c
+++ b/conversion/dcm2mnc/minc_file.c
@@ -897,7 +897,9 @@ void setup_minc_variables(int mincid, General_Info *general_info,
         while (temp[i] != 0 && !isdigit(temp[i]))
           i++;
         if (temp[i] == 0) {
-          fprintf(stderr, "WARNING: Age was not numeric!!\n");
+            if (G.Debug >= HI_LOGGING) {
+                fprintf(stderr, "WARNING: Age was not numeric!!\n");
+            }
         }
         else {
           age = atof(&temp[i]);
@@ -910,7 +912,9 @@ void setup_minc_variables(int mincid, General_Info *general_info,
           else if (temp[i] == 'D') /* age is in days */
             age /= 365.0;
           else if (temp[i] != 'Y') { /* age is in years */
-            fprintf(stderr, "WARNING: Age units (%s) unknown.\n", temp);
+            if (G.Debug >= HI_LOGGING) {
+                fprintf(stderr, "WARNING: Age units (%s) unknown.\n", temp);
+            }
             age = 0.0;
           }
           miattputdbl(mincid, varid, MIage, age);

--- a/conversion/dcm2mnc/pms_element_defs.h
+++ b/conversion/dcm2mnc/pms_element_defs.h
@@ -80,7 +80,10 @@ GLOBAL_ELEMENT(PMS_Private_group_creator_2            , 0x2005, 0x0011, LO);
 GLOBAL_ELEMENT(PMS_Private_group_creator_3            , 0x2005, 0x0012, LO);
 GLOBAL_ELEMENT(PMS_Private_group_creator_4            , 0x2005, 0x0013, LO);
 GLOBAL_ELEMENT(PMS_Private_group_creator_5            , 0x2005, 0x0014, LO);
-GLOBAL_ELEMENT(PMS_Acquisition_parameters_seq, 0x2005, 0x140f, SQ);
+GLOBAL_ELEMENT(PMS_Private_Rescale_intercept          , 0x2005, 0x100d, FL);
+GLOBAL_ELEMENT(PMS_Private_Rescale_slope              , 0x2005, 0x100e, FL);
+GLOBAL_ELEMENT(PMS_Acquisition_parameters_seq         , 0x2005, 0x140f, SQ);
+GLOBAL_ELEMENT(PMS_MRImageLabelType                   , 0x2005, 0x1429, CS);
 
 /* These values indicate the index of the B-values and gradient
  * orientations within the scan, and the total number of B-values and

--- a/conversion/dcm2mnc/spi_element_defs.h
+++ b/conversion/dcm2mnc/spi_element_defs.h
@@ -81,6 +81,8 @@ GLOBAL_ELEMENT(SPI_Saturation_regions                 , 0x0019, 0x1290, IS);
 GLOBAL_ELEMENT(SPI_Magnetic_field_strength            , 0x0019, 0x1412, DS);
 GLOBAL_ELEMENT(SPI_Base_raw_matrix_size               , 0x0019, 0x14d4, IS);
 
+GLOBAL_ELEMENT(SPI_Private_creator_0021               , 0x0021, 0x0011, LO);
+GLOBAL_ELEMENT(SPI_ICE_Dims                           , 0x0021, 0x1106, LO);
 GLOBAL_ELEMENT(SPI_Field_of_view                      , 0x0021, 0x1120, DS);
 GLOBAL_ELEMENT(SPI_Image_magnification_factor         , 0x0021, 0x1122, DS);
 GLOBAL_ELEMENT(SPI_View_direction                     , 0x0021, 0x1130, CS);
@@ -104,6 +106,7 @@ GLOBAL_ELEMENT(SPI_Number_of_slices_cur               , 0x0021, 0x1341, IS);
 GLOBAL_ELEMENT(SPI_Current_slice_number               , 0x0021, 0x1342, IS);
 GLOBAL_ELEMENT(SPI_Order_of_slices                    , 0x0021, 0x134f, IS);
 GLOBAL_ELEMENT(SPI_Number_of_echoes                   , 0x0021, 0x1370, IS);
+GLOBAL_ELEMENT(SPI_Locations_in_Acquisitions          , 0x0021, 0x104f, SS);
 
 /* These are the two large fields in Siemens files in which many parameters
  * are dumped. The ASCCONV block is located in the second (0029, 1020), but


### PR DESCRIPTION
Better conversion support of various PET datasets, multi-echo acquisitions, mosaic DICOM datasets, GEMS diffusion MRI datasets, Philips ASL datasets, Siemens private headers, slice order of fMRI datasets, RealWorldValue rescaling and Philips private header quantitative rescaling.

As mentioned on the MINC-development mailing list, this is the result of 4 years of internal development on dcm2mnc (with contributions from Massine Yahia, Dany Chagnon, Jiaxing Li and others) that we couldn't feed back in a more piecemeal approach. This fixes a wide range of issues, and offering this as take it or leave it, but happy to answer questions, and feel free to modify as you see fit.