### PR TITLE
avoid getting attributes for a dimension with no axis, like time axis

### DIFF
--- a/progs/mincresample/resample_volumes.c
+++ b/progs/mincresample/resample_volumes.c
@@ -562,6 +562,8 @@ void get_slice(long slice_num, VVolume *in_vol, VVolume *out_vol,
       dimid = ncvarid(in_vol->file->mincid, dimname);
       if (dimid == MI_ERROR) continue;
 
+      if (in_vol->file->world_axes[idim_in] == NO_AXIS) continue;
+
       /* Get attributes from variget_file_infoable */
       (void) miattget1(in_vol->file->mincid, dimid, MIstep, 
                        NC_DOUBLE, &separations[in_vol->file->world_axes[idim_in]]);


### PR DESCRIPTION
In case of time dimension, the `NO_AXIS` has a value of -1, this lead to call an array with negative index of -1 with `separations[in_vol->file->world_axes[idim_in]]`. In C, an array with negative index would lead problems related to memory location's value being overwritten. So a solution is proposed to only get attribute for world dimensions, and skip for time dimension by adding  `continue` with such condition.

This leads to issue typically with 4D input volumes with floating data type, when building in release mode with optimization.