### PR TITLE
add test for mincresample with 4D float volume

### DIFF
--- a/Testing/mincresample-test.sh
+++ b/Testing/mincresample-test.sh
@@ -10,6 +10,18 @@ if [[ ! -x $MINCRESAMPLE_BIN ]]; then
     MINCRESAMPLE_BIN=`which mincresample`;
 fi
 
+if [[ ! -x $MINCRESHAPE_BIN ]]; then
+    MINCRESHAPE_BIN=`which mincreshape`;
+fi
+
+if [[ ! -x $MINCCONCAT_BIN ]]; then
+    MINCCONCAT_BIN=`which mincconcat`;
+fi
+
+if [[ ! -x $MINCCMP_BIN ]]; then
+    MINCCMP_BIN=`which minccmp`;
+fi
+
 # Test the standard (no-normalize) case. This has always worked.
 $MINCRESAMPLE_BIN -clobber test-rnd.mnc mincresample-out.mnc
 r1=`$MINCSTATS_BIN -quiet -sum mincresample-out.mnc`
@@ -22,6 +34,18 @@ $MINCRESAMPLE_BIN -keep_real_range -clobber test-rnd.mnc mincresample-out.mnc
 r2=`$MINCSTATS_BIN -quiet -sum mincresample-out.mnc`
 if [[ $r2 != "250" ]]; then
   echo "Problem with -keep_real_range operation:" $r2
+  exit 1;
+fi;
+# Now test mincresample converted properly a 4D float volume
+# Make a input volume
+$MINCRESHAPE_BIN -float -colsize 125 -rowsize 1 test-rnd.mnc test-rnd-reshaped.mnc -clobber
+$MINCCONCAT_BIN -concat_dimension time test-rnd-reshaped.mnc test-rnd-reshaped-4d.mnc -clobber
+$MINCRESAMPLE_BIN -clobber test-rnd-reshaped-4d.mnc mincresample-out.mnc
+r3=`$MINCCMP_BIN test-rnd-reshaped-4d.mnc mincresample-out.mnc`
+# Verify if xcorr is 1
+xcorr=`echo $r3 | grep -o 'xcorr: [^ ]*' | cut -d ' ' -f2`
+if [[ $xcorr != 1 ]]; then
+  echo "Problem with output file compared with input file, xcorr is" $xcorr
   exit 1;
 fi;
 echo "OK."


### PR DESCRIPTION
this is a test update for the mincresample bug fix, so this test should fail before the bug fix, and should succeed after the fix.

FYI, please use release mode to build and test the executables before vs after the bug fix, since this bug only happened in release mode built.

the criteria of succeed is to compare the input and output of `mincresample <input.mnc> <output.mnc>`, using `minccmp` for comparison, in the case of correct fix, the `xcorr` is supposed to be or very close to 1 because the input and output are supposed to be identic. 