### PR TITLE
Fix old-style k&r shadow define

### DIFF
--- a/conversion/minctoecat/ecat_write.c
+++ b/conversion/minctoecat/ecat_write.c
@@ -54,7 +54,7 @@ int mat_close(FILE *fptr);
 
 MatrixFile     *matrix_create(const char *fname, Main_header * proto_mhptr) {
   MatrixFile     *mptr = NULL;
-  FILE           *fptr, *mat_create();
+  FILE           *fptr;
   
   matrix_errno = MAT_OK;
   matrix_errtxt[0] = '\0';
@@ -124,7 +124,7 @@ FILE *mat_create(const char  *fname,Main_header *mhead) {
 }
 
 FILE *mat_open( const char *fname, char *fmode) {
-  FILE *fopen(), *fptr;
+  FILE *fptr;
   
   matrix_errno = MAT_OK;
   matrix_errtxt[0] = '\0';


### PR DESCRIPTION
mat_open was already defined elsewhere and fopen comes from stdio.h

With help from GLM-5.1