### PR TITLE
Do not pass DOWNLOAD_EXTRACT_TIMESTAMP to CMake older than 3.24

### DIFF
--- a/Testing/CMakeLists.txt
+++ b/Testing/CMakeLists.txt
@@ -221,7 +221,7 @@ if(MT_BUILD_DCM2MNC_TESTS)
   if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.24)
     set(_extract_timestamp DOWNLOAD_EXTRACT_TIMESTAMP TRUE)
   else()
-    set(_extract_timestamp "")
+    unset(_extract_timestamp)
   endif()
 
   ExternalProject_Add(dcm_qa_data

--- a/Testing/CMakeLists.txt
+++ b/Testing/CMakeLists.txt
@@ -210,25 +210,36 @@ if(MT_BUILD_DCM2MNC_TESTS)
   set(_datadir      ${CMAKE_CURRENT_BINARY_DIR}/dcm2niix_data)
 
   # Download-only ExternalProjects — configure/build/install are no-ops.
-  # DOWNLOAD_EXTRACT_TIMESTAMP TRUE suppresses the CMP0135 warning on CMake >= 3.24.
   # ExternalProject flattens the single <repo>-<sha>/ top-level dir that GitHub
   # puts inside archive tarballs, so In/... resolves directly under SOURCE_DIR.
+  #
+  # DOWNLOAD_EXTRACT_TIMESTAMP TRUE suppresses the CMP0135 warning, and CMake
+  # only accepts it from 3.24. Passing it to an older CMake is not ignored: it
+  # survives into the generated extract script and the download step dies with
+  # "execute_process given unknown argument". This file must work on the 3.10
+  # this project asks for, so give the argument only where it exists.
+  if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.24)
+    set(_extract_timestamp DOWNLOAD_EXTRACT_TIMESTAMP TRUE)
+  else()
+    set(_extract_timestamp "")
+  endif()
+
   ExternalProject_Add(dcm_qa_data
     URL        "https://github.com/neurolabusc/dcm_qa/archive/4f85d067c8b61d12cec1689f8516cc30cd583d65.tar.gz"
     SOURCE_DIR "${_datadir}/dcm_qa"
-    DOWNLOAD_EXTRACT_TIMESTAMP TRUE
+    ${_extract_timestamp}
     CONFIGURE_COMMAND "" BUILD_COMMAND "" INSTALL_COMMAND "")
 
   ExternalProject_Add(dcm_qa_nih_data
     URL        "https://github.com/neurolabusc/dcm_qa_nih/archive/d302d6e241dda747b79ee1724ada3200179755a2.tar.gz"
     SOURCE_DIR "${_datadir}/dcm_qa_nih"
-    DOWNLOAD_EXTRACT_TIMESTAMP TRUE
+    ${_extract_timestamp}
     CONFIGURE_COMMAND "" BUILD_COMMAND "" INSTALL_COMMAND "")
 
   ExternalProject_Add(dcm_qa_uih_data
     URL        "https://github.com/neurolabusc/dcm_qa_uih/archive/d729bdd785d37ad5f1ed479c305a76f370d8011b.tar.gz"
     SOURCE_DIR "${_datadir}/dcm_qa_uih"
-    DOWNLOAD_EXTRACT_TIMESTAMP TRUE
+    ${_extract_timestamp}
     CONFIGURE_COMMAND "" BUILD_COMMAND "" INSTALL_COMMAND "")
 
   # Each test converts one DICOM series and checks the output geometry +


### PR DESCRIPTION
`MT_BUILD_DCM2MNC_TESTS=ON` fails to build on any CMake between the 3.10 this project asks for in `CMAKE_MINIMUM_REQUIRED` and 3.23:

```
CMake Error at .../dcm_qa_data-stamp/extract-dcm_qa_data.cmake:26 (execute_process):
  execute_process given unknown argument "DOWNLOAD_EXTRACT_TIMESTAMP".
gmake[2]: *** [.../dcm_qa_data-download] Error 1
```

`ExternalProject_Add` gained `DOWNLOAD_EXTRACT_TIMESTAMP` in CMake 3.24. An older CMake does not ignore the argument — it copies it into the generated extract script, where `execute_process` rejects it and the download step dies. All three `dcm_qa*` data projects passed it unconditionally.

## The fix

Give the argument through a variable that is empty below 3.24:

```cmake
if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.24)
  set(_extract_timestamp DOWNLOAD_EXTRACT_TIMESTAMP TRUE)
else()
  set(_extract_timestamp "")
endif()
```

An unquoted empty variable expands to no arguments at all, so nothing reaches `ExternalProject_Add` on an older CMake. Checked with a two-line `cmake -P` script: the same call site takes 6 arguments with the variable set and 4 with it empty. CMake 3.24 and newer keep the CMP0135 warning suppressed exactly as before.

## Where it turned up

Building minc-toolkit-v2 on `ubuntu:22.04`, which has CMake 3.22 and is the oldest glibc the relocatable tarball targets (BIC-MNI/minc-toolkit-v2#234). The dcm2mnc tests are switched off in those jobs until this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A5NQ3wnC2yygmxWeM5NxNm